### PR TITLE
Move cell comments to markdown

### DIFF
--- a/polycat.ipynb
+++ b/polycat.ipynb
@@ -31,13 +31,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<small>The columns of the matrix M contain the coordinates of a 5-simplex for which the canonical frame gives a 1-loop </small>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "eb7c1773",
    "metadata": {},
    "outputs": [],
    "source": [
-    "#The columns of the matrix M contain the coordinates of a 5-simplex for which the canonical frame gives a 1-loop\n",
     "M = Matrix([[-3,-2,-1,1,2,3],\n",
     "            [-1,1,0,0,1,-1],\n",
     "            [-1,1,0,1,-1,1],\n",
@@ -46,6 +52,13 @@
     "P = Polyhedron(vertices=M.columns())\n",
     "d = P.ambient_dim()\n",
     "F = canonical_frame(d)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<small>Checking that the frame is admissible </small>"
    ]
   },
   {
@@ -66,8 +79,14 @@
     }
    ],
    "source": [
-    "#Checking that the frame is admissible\n",
     "is_admissible(F,P)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<small>Looking for loops </small>"
    ]
   },
   {
@@ -85,12 +104,18 @@
     }
    ],
    "source": [
-    "#Looking for loops\n",
     "for k in range(d):\n",
     "    D = cell_k_string(P,k,pure=True)\n",
     "    acyc,cert = D.is_directed_acyclic(certificate=True)\n",
     "    if not acyc:\n",
     "        print('there is a ', k, ' loop: ',cert)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<small>The digraph of cellular 1-strings on the 2-faces of P </small>"
    ]
   },
   {
@@ -722,7 +747,6 @@
     }
    ],
    "source": [
-    "#The digraph of cellular 1-strings on the 2-faces of P\n",
     "D = cell_k_string(P,1,pure=True)\n",
     "D.show3d(vertex_labels=True,edge_size=0.005)"
    ]
@@ -736,14 +760,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<small>The columns of the matrix M contain the coordinates of a 6-simplex for which the frame F has a 2-loop </small>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 6,
    "id": "269eaad7",
    "metadata": {},
    "outputs": [],
    "source": [
-    "#The columns of the matrix M contain the coordinates of a 6-simplex for which the frame F has a 2-loop\n",
-    "\n",
     "M = Matrix([[0,10,0,0,7,2,3],\n",
     "            [0,0,10,0,3,7,2],\n",
     "            [0,0,0,10,2,3,7],\n",
@@ -760,6 +789,13 @@
     "\n",
     "P = Polyhedron(vertices=M.columns())\n",
     "d = P.ambient_dim()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<small>Checking that the frame is admissible </small>"
    ]
   },
   {
@@ -780,8 +816,14 @@
     }
    ],
    "source": [
-    "#Checking that the frame is admissible\n",
     "is_admissible(F,P)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<small>Looking for loops </small>"
    ]
   },
   {
@@ -799,12 +841,18 @@
     }
    ],
    "source": [
-    "#Looking for loops\n",
     "for k in range(d):\n",
     "    D = cell_k_string(P,k,frame=F,pure=True)\n",
     "    acyc,cert = D.is_directed_acyclic(certificate=True)\n",
     "    if not acyc:\n",
     "        print('there is a ', k, ' loop: ',cert)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<small>The digraph of cellular 1-strings on the 2-faces of P </small>"
    ]
   },
   {
@@ -1436,9 +1484,15 @@
     }
    ],
    "source": [
-    "#The digraph of cellular 1-strings on the 2-faces of P\n",
     "D = cell_k_string(P,2,frame=F,pure=True)\n",
     "D.show3d(vertex_labels=True,edge_size=0.005)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<small>The 3-dimensional projection of P with the frame </small>"
    ]
   },
   {
@@ -2070,7 +2124,6 @@
     }
    ],
    "source": [
-    "#The 3-dimensional projection of P with the frame\n",
     "Proj = ith_projection(F, 3)\n",
     "PP = Proj*P\n",
     "PP.show()"
@@ -2085,14 +2138,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<small>The columns of the matrix M contain the coordinates of a random d-simplex </small>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 11,
    "id": "94a345b7",
    "metadata": {},
    "outputs": [],
    "source": [
-    "#The columns of the matrix M contain the coordinates of a random d-simplex\n",
-    "\n",
     "d = 8\n",
     "\n",
     "import random\n",
@@ -2101,6 +2159,13 @@
     "\n",
     "P = Polyhedron(vertices=M.columns())\n",
     "F = canonical_frame(d)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<small>Checking that the frame is admissible </small>"
    ]
   },
   {
@@ -2121,8 +2186,14 @@
     }
    ],
    "source": [
-    "#Checking that the frame is admissible\n",
     "is_admissible(F,P)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<small>Looking for loops </small>"
    ]
   },
   {
@@ -2142,7 +2213,6 @@
     }
    ],
    "source": [
-    "#Looking for loops\n",
     "for k in range(d):\n",
     "    D = cell_k_string(P,k,frame=F,pure=True)\n",
     "    acyc,cert = D.is_directed_acyclic(certificate=True)\n",
@@ -2159,14 +2229,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<small>The columns of the matrix M contain the coordinates of a standard d-simplex, F is a random frame </small>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 14,
    "id": "fbff97ca",
    "metadata": {},
    "outputs": [],
    "source": [
-    "#The columns of the matrix M contain the coordinates of a standard d-simplex, F is a random frame\n",
-    "\n",
     "d = 8\n",
     "\n",
     "import random\n",
@@ -2174,6 +2249,13 @@
     "M = identity_matrix(RR,d+1)\n",
     "P = Polyhedron(vertices=M.columns())\n",
     "F = Matrix(RR, d+1, d+1, lambda i, j: random.normalvariate(0, 1)).columns()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<small>Checking that the frame is admissible </small>"
    ]
   },
   {
@@ -2194,8 +2276,14 @@
     }
    ],
    "source": [
-    "#Checking that the frame is admissible\n",
     "is_admissible(F,P)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<small>Looking for loops </small>"
    ]
   },
   {
@@ -2207,7 +2295,6 @@
    },
    "outputs": [],
    "source": [
-    "#Looking for loops\n",
     "for k in range(d):\n",
     "    D = cell_k_string(P,k,frame=F,pure=True)\n",
     "    acyc,cert = D.is_directed_acyclic(certificate=True)\n",


### PR DESCRIPTION
## Summary
- show explanations in `polycat.ipynb` as small-font markdown cells
- remove comment lines from code cells

## Testing
- `python3 -m json.tool polycat.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_6872218734348324bd98dbfe7b3c3834